### PR TITLE
Update terminus.py 匹配新验证码长度

### DIFF
--- a/embykeeper/telechecker/bots/terminus.py
+++ b/embykeeper/telechecker/bots/terminus.py
@@ -8,4 +8,4 @@ class TerminusCheckin(BotCheckin):
     bot_username = "EmbyPublicBot"
     bot_checkin_cmd = ["/cancel", "/checkin"]
     bot_text_ignore = ["会话已取消", "没有活跃的会话"]
-    bot_captcha_len = 3
+    bot_captcha_len = [2, 3]


### PR DESCRIPTION
<!-- 感谢您帮助Embykeeper的开发: 你的努力为社区做出了杰出贡献! -->

## 简介

终点站Emby的签到验证码长度又改回两位了，不清楚未来会不会再做调整，目前将长度判断参数调整为2，3

Checklist:

- [ ✓] 我已经做了对应的测试, 并确认代码有效.
- [✓ ] 我同时更新了文档, 或确认我的更新不需要修改文档.

## 缘由
验证码长度又改回两位了，似乎官方有意限制脚本签到，因此不清楚未来会不会再做调整，目前将长度判断参数调整为2，3，以后视情况再做调整
