### PR TITLE
bug fix: embykeepweb缺少依赖trio

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ onnxruntime==1.14.0
 httpx[http2]
 socksio
 telethon
+trio


### PR DESCRIPTION
<!-- 感谢您帮助Embykeeper的开发: 你的努力为社区做出了杰出贡献! -->

## 简介

修复 docker web 部署报错

Checklist:

- [x] 我已经做了对应的测试, 并确认代码有效.

## 缘由
huggingface 部署报错
Traceback (most recent call last):
  File "/opt/venv/bin/embykeeperweb", line 5, in <module>
    from embykeeperweb.app import cli
  File "/opt/venv/lib/python3.8/site-packages/embykeeperweb/app.py", line 1, in <module>
    import trio  # fix https://github.com/python-trio/trio/issues/3015
ModuleNotFoundError: No module named 'trio'
Traceback (most recent call last):
  File "/opt/venv/bin/embykeeperweb", line 5, in <module>
    from embykeeperweb.app import cli
  File "/opt/venv/lib/python3.8/site-packages/embykeeperweb/app.py", line 1, in <module>
    import trio  # fix https://github.com/python-trio/trio/issues/3015
ModuleNotFoundError: No module named 'trio'
